### PR TITLE
density map for calc_count_count

### DIFF
--- a/mi_ksg_viz.m
+++ b/mi_ksg_viz.m
@@ -129,11 +129,36 @@ classdef mi_ksg_viz < handle
                             
                             % Make figure
                             figure()
-                            plot(x_plot , y_plot, 'x')
                             hold on
                             xlabel('Discrete Value: X')
                             ylabel('Discrete Value: Y')
                             title('P(X,Y) Discrete Joint Distribution')
+                            
+                            % Make density map 
+                            pts = linspace(-1, 20, 100);
+                            [X, Y] = meshgrid(pts);
+                            D = pdist2([x_plot(:) y_plot(:)], [X(:) Y(:)], 'euclidean', 'Smallest', 1);
+
+                            % Plot scattered data:
+                            subplot(1, 2, 1);
+                            scatter(x_plot, y_plot, 'x');
+                            axis equal;
+                            set(gca, 'XLim', pts([1 end]), 'YLim', pts([1 end]));
+                            xlabel('Discrete Value: X')
+                            ylabel('Discrete Value: Y')
+                            title('P(X,Y) Discrete Joint Distribution')
+                            
+                            % Plot heatmap:
+                            subplot(1, 2, 2);
+                            imagesc(pts, pts, reshape(D, size(X)));
+                            axis equal;
+                            set(gca, 'XLim', pts([1 end]), 'YLim', pts([1 end]), 'YDir', 'normal');
+                            colormap(flip(parula(), 1));
+                            xlabel('Discrete Value: X')
+                            ylabel('Discrete Value: Y')
+                            title('P(X,Y) Density Map')
+                            
+                            
                         elseif all(rem(x,1) == 0) | all(rem(y,1) == 0)
                             % Add jitter only to the variable that is discrete, which for our data, will always be the second variable.
                             if all(rem(x,1) == 0)

--- a/mi_ksg_viz.m
+++ b/mi_ksg_viz.m
@@ -127,20 +127,13 @@ classdef mi_ksg_viz < handle
                             x_plot = x + 0.2*rand(size(x));
                             y_plot = y + 0.2*rand(size(y));
                             
-                            % Make figure
-                            figure()
-                            hold on
-                            xlabel('Discrete Value: X')
-                            ylabel('Discrete Value: Y')
-                            title('P(X,Y) Discrete Joint Distribution')
-                            
                             % Make density map 
-                            pts = linspace(-1, 20, 100);
-                            [X, Y] = meshgrid(pts);
-                            D = pdist2([x_plot(:) y_plot(:)], [X(:) Y(:)], 'euclidean', 'Smallest', 1);
-
+                            pts = linspace(0, max(max(x),max(y)),max(max(x),max(y)));
+                            N = histcounts2(y(:), x(:), pts, pts);
+                            N = log(N);
+                            
                             % Plot scattered data:
-                            subplot(1, 2, 1);
+                            figure()
                             scatter(x_plot, y_plot, 'x');
                             axis equal;
                             set(gca, 'XLim', pts([1 end]), 'YLim', pts([1 end]));
@@ -149,14 +142,15 @@ classdef mi_ksg_viz < handle
                             title('P(X,Y) Discrete Joint Distribution')
                             
                             % Plot heatmap:
-                            subplot(1, 2, 2);
-                            imagesc(pts, pts, reshape(D, size(X)));
+                            figure()
+                            imagesc(pts, pts, N);
                             axis equal;
                             set(gca, 'XLim', pts([1 end]), 'YLim', pts([1 end]), 'YDir', 'normal');
-                            colormap(flip(parula(), 1));
                             xlabel('Discrete Value: X')
                             ylabel('Discrete Value: Y')
                             title('P(X,Y) Density Map')
+                            cBar = colorbar('Direction', 'normal', 'Ticks', 1:max(N, [], 'all'));
+                            cBar.Label.String = "log(# of data points)";
                             
                             
                         elseif all(rem(x,1) == 0) | all(rem(y,1) == 0)

--- a/mi_ksg_viz.m
+++ b/mi_ksg_viz.m
@@ -128,8 +128,8 @@ classdef mi_ksg_viz < handle
                             y_plot = y + 0.2*rand(size(y));
                             
                             % Make density map 
-                            pts = linspace(0, max(max(x),max(y)),max(max(x),max(y)));
-                            N = histcounts2(y(:), x(:), pts, pts);
+                            pts = linspace(0, max(max(x), max(y)) + 1, max(max(x), max(y)) + 2) 
+			    N = histcounts2(y(:), x(:), pts, pts);
                             N = log(N);
                             
                             % Plot scattered data:


### PR DESCRIPTION
Updated mi_ksg_viz.m to generate a figure that displays a density map of the joint histogram on a log scale. It utilizes histcount2() to determine the number of points and uses integer size bins. Ex:

![image](https://user-images.githubusercontent.com/43937499/84947432-2f2a6500-b0b8-11ea-9fc3-431326aae483.png)

