### PR TITLE
Added PCA plots for mi_ksg_viz for multi-dim data

### DIFF
--- a/mi_ksg_viz.m
+++ b/mi_ksg_viz.m
@@ -85,7 +85,8 @@ classdef mi_ksg_viz < handle
         % Audit Plots from mi_analysis class
         function audit_plots(mi_analysis)
             
-            for iGroup = 1:size(size(mi_analysis.arrMIcore))
+	    % Iterating through the core objects
+	    for iGroup = 1:size(mi_analysis.arrMIcore,1)
                 coreObj = mi_analysis.arrMIcore{iGroup,1};
                 
                 % FOR NOW, NO AUDIT PLOTS FOR BEHAVIOR SUBCLASSES
@@ -115,9 +116,41 @@ classdef mi_ksg_viz < handle
                     ylabel('N Cycles')
                     title('Histogram for Y')
                     
-                    % Also skip audit plots for data where both x and y are multi-dimensional
+                    % For multidimensional data
                     if all(size(x) > 1) & all(size(y) > 1)
-                        continue
+                        
+                        % Plot the first pc1x and pc1y against each other
+                        % Variability plot for x and y individually 
+                        
+                        % Obtain relevant PCA values
+                        [~, scorex, latentx] = pca(x);
+                        [~, scorey, latenty] = pca(y); 
+                        
+                        % Plot the first components against each other 
+                        figure()
+                        scatter(scorex(:,1), scorey(:,1), 'x');
+                        axis equal; 
+                        xlabel('1st X Principle Component')
+                        ylabel('1st Y Principle Component')
+                        title('PCA Joint Plot')
+                        
+                        % Plot variability in x components 
+                        figure()
+                        cumsumx = sum(latentx);
+                        perVarx = latentx / cumsumx;
+                        bar(perVarx)
+                        xlabel('Principle Component')
+                        ylabel('Percent Variability Explained')
+                        title('Scree Plot for X')
+                        
+                        % Plot variability in y components 
+                        figure()
+                        cumsumy = sum(latenty);
+                        perVary = latenty / cumsumy;
+                        bar(perVary)
+                        xlabel('Principle Component')
+                        ylabel('Percent Variability Explained')
+                        title('Scree Plot for Y')
                     else
                         % Check for discrete data in both variables
                         if all(rem(x,1) == 0) & all(rem(y,1) == 0)
@@ -128,8 +161,8 @@ classdef mi_ksg_viz < handle
                             y_plot = y + 0.2*rand(size(y));
                             
                             % Make density map 
-                            pts = linspace(0, max(max(x), max(y)) + 1, max(max(x), max(y)) + 2) 
-			    N = histcounts2(y(:), x(:), pts, pts);
+                            pts = linspace(0, max(max(x), max(y)) + 1, max(max(x), max(y)) + 2); 
+			                N = histcounts2(y(:), x(:), pts, pts);
                             N = log(N);
                             
                             % Plot scattered data:


### PR DESCRIPTION
# PCA & Scree Plots for mi_ksg_viz.m class

Added audit plots for multidimensional data for when both X & Y are multidimensional.

## PCA Joint Plot 

> Plots the first principle component of X against the first principle component of Y via MATLAB's pca() function

![image](https://user-images.githubusercontent.com/43937499/87315290-54ad6180-c4f2-11ea-8133-645a2b19fc8b.png)

## PCA Scree Plots

> Plots the percent variability explained of each principle component for the X and Y variables via MATLAB's pca() function

![image](https://user-images.githubusercontent.com/43937499/87315658-ace46380-c4f2-11ea-985d-253cd7567504.png)
